### PR TITLE
Fixing default app so it works out of the box.

### DIFF
--- a/app/models/Example.php
+++ b/app/models/Example.php
@@ -5,11 +5,7 @@ use \core as core;
 
 Class Example extends core\Model
 {
-
     public function fetchSession() {
-
-        return $this->database->table('Session')->fetch();
-
+//        return $this->database->table('Session')->fetch();
     }
-
 }

--- a/app/modules/example/controllers/Home.php
+++ b/app/modules/example/controllers/Home.php
@@ -31,7 +31,7 @@ Class Home extends core\Controller {
 
         $example = $this->load->model('example');
 
-        print_r($example->fetchSession());die();
+//        print_r($example->fetchSession());die();
 
         $layout = $this->load->view(
             'example/home',


### PR DESCRIPTION
The default app as installed by composer cannot work if using the database or session handler with database before configuring it.

It doesn't make sense to allow someone to composer create-project zewa/app if the app isn't going to work out of the box.

Further, if we're using bower to optionally install bootstrap and jquery ui then we might want to add post install scripts or instructions to composer and the repo home page that explains that bower is used and outline how it's used so that a default install doesn't just throw 404's for the non existent css/js
